### PR TITLE
Fetch remote before testing whether the publish branch exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM ubuntu:18.04
 
 LABEL "com.github.actions.name"="Deploy to GitHub Pages for Static Site Generator"
 LABEL "com.github.actions.description"="A GitHub Action to deploy your static site to GitHub Pages with Static Site Generator"
@@ -9,9 +9,11 @@ LABEL "repository"="https://github.com/peaceiris/actions-gh-pages"
 LABEL "homepage"="https://github.com/peaceiris/actions-gh-pages"
 LABEL "maintainer"="peaceiris"
 
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    openssh-client
+    openssh-client \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,19 +3,27 @@
 set -e
 # set -ex
 
+function print_error() {
+    echo -e "\e[31mERROR: ${1}\e[m"
+}
+
+function print_message() {
+    echo -e "\e[36mMESSAGE: ${1}\e[m"
+}
+
 # check values
 if [ -z "${GITHUB_TOKEN}" ]; then
-    echo "error: not found GITHUB_TOKEN"
+    print_error "not found GITHUB_TOKEN"
     exit 1
 fi
 
 if [ -z "${PUBLISH_BRANCH}" ]; then
-    echo "error: not found PUBLISH_BRANCH"
+    print_error "not found PUBLISH_BRANCH"
     exit 1
 fi
 
 if [ -z "${PUBLISH_DIR}" ]; then
-    echo "error: not found PUBLISH_DIR"
+    print_error "not found PUBLISH_DIR"
     exit 1
 fi
 
@@ -31,6 +39,11 @@ else
     cd "${PUBLISH_DIR}"
     git init
     git checkout --orphan "${remote_branch}"
+fi
+
+if [ -z "$(git status -z)" ]; then
+    print_message "nothing to commit, working tree clean"
+    exit 0
 fi
 
 # push to publishing branch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # check values
 if [ -z "${GITHUB_TOKEN}" ]; then
     echo "error: not found GITHUB_TOKEN"
@@ -15,19 +17,25 @@ if [ -z "${PUBLISH_DIR}" ]; then
     echo "error: not found PUBLISH_DIR"
     exit 1
 fi
-cd "${PUBLISH_DIR}" || exit 1
 
-# initialize git
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 remote_branch="${PUBLISH_BRANCH}"
-git init
-git config user.name "${GITHUB_ACTOR}"
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-git remote add origin "${remote_repo}"
+
+local_dir="$(uuidgen)"
+if git clone --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
+    cd "${local_dir}"
+    git rm -r '*'
+    cp -rf "${PUBLISH_DIR}"/* "${PUBLISH_DIR}"/.* .
+else
+    cd "${PUBLISH_DIR}"
+    git init
+    git remote add origin "${remote_repo}"
+    git checkout --orphan "${remote_branch}"
+fi
 
 # push to publishing branch
-git checkout "${remote_branch}" || git checkout --orphan "${remote_branch}"
+git config user.name "${GITHUB_ACTOR}"
+git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git add --all
-timestamp=$(date -u)
-git commit -m "Automated deployment: ${timestamp} ${GITHUB_SHA}"
+git commit -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
 git push origin "${remote_branch}" --force

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -ex
 
 # check values
 if [ -z "${GITHUB_TOKEN}" ]; then
@@ -21,21 +21,22 @@ fi
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 remote_branch="${PUBLISH_BRANCH}"
 
-local_dir="$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32)"
-if git clone --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
+local_dir="${HOME}/$(tr -cd 'a-f0-9' < /dev/urandom | head -c 32)"
+if git clone --depth=1 --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
     cd "${local_dir}"
     git rm -r '*'
-    cp -rf "${PUBLISH_DIR}"/* "${PUBLISH_DIR}"/.* .
+    cp -rf $(find "${GITHUB_WORKSPACE}/${PUBLISH_DIR}" -maxdepth 1 | tail -n +2) "${local_dir}/"
 else
     cd "${PUBLISH_DIR}"
     git init
-    git remote add origin "${remote_repo}"
     git checkout --orphan "${remote_branch}"
 fi
 
 # push to publishing branch
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+git remote rm origin || true
+git remote add origin "${remote_repo}"
 git add --all
 git commit -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
-git push origin "${remote_branch}" --force
+git push origin "${remote_branch}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ function print_error() {
     echo -e "\e[31mERROR: ${1}\e[m"
 }
 
-function print_message() {
+function print_info() {
     echo -e "\e[36mMESSAGE: ${1}\e[m"
 }
 
@@ -51,3 +51,4 @@ git remote add origin "${remote_repo}"
 git add --all
 git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
 git push origin "${remote_branch}"
+print_info "INFO: ${GITHUB_SHA} was successfully deployed"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,9 @@ local_dir="${HOME}/$(tr -cd 'a-f0-9' < /dev/urandom | head -c 32)"
 if git clone --depth=1 --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
     cd "${local_dir}"
     git rm -r '*'
-    cp -rf $(find "${GITHUB_WORKSPACE}/${PUBLISH_DIR}" -maxdepth 1 | tail -n +2) "${local_dir}/"
+    find "${GITHUB_WORKSPACE}/${PUBLISH_DIR}" -maxdepth 1 | \
+        tail -n +2 | \
+        xargs -I % cp -rf % "${local_dir}/"
 else
     cd "${PUBLISH_DIR}"
     git init

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ function print_error() {
 }
 
 function print_info() {
-    echo -e "\e[36mMESSAGE: ${1}\e[m"
+    echo -e "\e[36mINFO: ${1}\e[m"
 }
 
 # check values
@@ -51,4 +51,4 @@ git remote add origin "${remote_repo}"
 git add --all
 git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
 git push origin "${remote_branch}"
-print_info "INFO: ${GITHUB_SHA} was successfully deployed"
+print_info "${GITHUB_SHA} was successfully deployed"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ fi
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 remote_branch="${PUBLISH_BRANCH}"
 
-local_dir="$(uuidgen)"
+local_dir="$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32)"
 if git clone --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
     cd "${local_dir}"
     git rm -r '*'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,12 @@ if [ -z "${PUBLISH_DIR}" ]; then
     exit 1
 fi
 
+GIT_STATUS=$(git status -z | tr -d '\0')
+if [ -z "${GIT_STATUS}" ]; then
+    print_message "nothing to commit, working tree clean"
+    exit 0
+fi
+
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 remote_branch="${PUBLISH_BRANCH}"
 
@@ -41,12 +47,6 @@ else
     cd "${PUBLISH_DIR}"
     git init
     git checkout --orphan "${remote_branch}"
-fi
-
-GIT_STATUS=$(git status -z | tr -d '\0')
-if [ -z "${GIT_STATUS}" ]; then
-    print_message "nothing to commit, working tree clean"
-    exit 0
 fi
 
 # push to publishing branch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -ex
+set -e
+# set -ex
 
 # check values
 if [ -z "${GITHUB_TOKEN}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,12 +27,6 @@ if [ -z "${PUBLISH_DIR}" ]; then
     exit 1
 fi
 
-GIT_STATUS=$(git status -z | tr -d '\0')
-if [ -z "${GIT_STATUS}" ]; then
-    print_message "nothing to commit, working tree clean"
-    exit 0
-fi
-
 remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 remote_branch="${PUBLISH_BRANCH}"
 
@@ -55,5 +49,5 @@ git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git remote rm origin || true
 git remote add origin "${remote_repo}"
 git add --all
-git commit -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
 git push origin "${remote_branch}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,8 @@ else
     git checkout --orphan "${remote_branch}"
 fi
 
-if [ -z "$(git status -z)" ]; then
+GIT_STATUS=$(git status -z | tr -d '\0')
+if [ -z "${GIT_STATUS}" ]; then
     print_message "nothing to commit, working tree clean"
     exit 0
 fi


### PR DESCRIPTION
This re-uses the existing branch rather than always overwriting it with a new branch with single commit.

Signed-off-by: Michael Smith <michael.smith@puppet.com>