### PR TITLE
Simplify MkDocs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install -r ./requirements.txt
+        pip install mkdocs
 
     - name: Build with MkDocs
       run: mkdocs build


### PR DESCRIPTION
This might be a very näive suggestion, but using a ```requirements.txt``` for something as simple as using MkDocs seems like an overkill. What do you think?