### PR TITLE
Add step to check for MkDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ jobs:
         pip install --upgrade pip
         pip install -r ./requirements.txt
 
+    - name: Check MkDocs
+      run: mkdocs --version
+
     - name: Build with MkDocs
       run: mkdocs build
 


### PR DESCRIPTION
Better safe then sorry, I'm suggesting a step that just tries to run MkDocs in a simple action before actually trying to build