### PR TITLE
Optional empty commits

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,10 +1,6 @@
 name: docker image ci
 
-on:
-  push:
-    branches:
-    - master
-    - 'release-v*'
+on: push
 
 jobs:
   test:
@@ -19,16 +15,6 @@ jobs:
       run: |
         docker build . --file Dockerfile --tag ${DOCKER_IMAGE} ||
         (echo -e "\e[31m[${GITHUB_WORKFLOW}] failed to build\e[m" && exit 1)
-
-    # - name: push latest image
-    #   if: endsWith(github.ref, 'master')
-    #   env:
-    #     DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/action:latest
-    #     PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
-    #   run: |
-    #     echo ${PKG_GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin &&
-    #     docker push ${DOCKER_IMAGE} &&
-    #     docker logout
 
   shellcheck:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of Contents
     - [:star: Pull action image from Docker Hub](#star-pull-action-image-from-docker-hub)
     - [:star: `PERSONAL_TOKEN`](#star-personal_token)
     - [:star: `GITHUB_TOKEN`](#star-github_token)
+    - [:star: Suppressing empty commits](#star-suppressing-empty-commits)
 - [Examples](#examples)
   - [Static Site Generators with Node.js](#static-site-generators-with-nodejs)
   - [Gatsby](#gatsby)
@@ -156,7 +157,20 @@ By pulling docker images, you can reduce the overall execution time of your work
 + GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+#### :star: Suppressing empty commits
 
+By default, a commit will always be generated and pushed to the `PUBLISH_BRANCH`, even if nothing changed. If you want to suppress this behavior, set the optional parameter `emptyCommits` to `false`. For example:
+
+```yaml
+- name: deploy
+  uses: peaceiris/actions-gh-pages@v2.2.0
+  env:
+    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+    PUBLISH_BRANCH: gh-pages
+    PUBLISH_DIR: ./public
+  with:
+    emptyCommits: false
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ By pulling docker images, you can reduce the overall execution time of your work
 
 #### :star: Suppressing empty commits
 
-By default, a commit will always be generated and pushed to the `PUBLISH_BRANCH`, even if nothing changed. If you want to suppress this behavior, set the optional parameter `emptyCommits` to `false`. For example:
+By default, a commit will always be generated and pushed to the `PUBLISH_BRANCH`, even if nothing changed. If you want to suppress this behavior, set the optional parameter `emptyCommits` to `false`. cf. [Issue #21]
+
+[Issue #21]: https://github.com/peaceiris/actions-gh-pages/issues/21
+
+For example:
 
 ```yaml
 - name: deploy
@@ -171,6 +175,8 @@ By default, a commit will always be generated and pushed to the `PUBLISH_BRANCH`
   with:
     emptyCommits: false
 ```
+
+
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -7,3 +7,8 @@ runs:
 branding:
   icon: 'upload-cloud'
   color: 'blue'
+inputs:
+  emptyCommits:
+    description: 'If empty commits should be made to the publication branch'
+    required: false
+    default: 'true'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,11 +73,11 @@ git remote add origin "${remote_repo}"
 git add --all
 
 print_info "Allowing empty commits: ${INPUT_EMPTYCOMMITS}"
-if [[ ${INPUT_EMPTYCOMMITS} == "true" ]]
-then
-    git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+COMMIT_MESSAGE="Automated deployment: $(date -u) ${GITHUB_SHA}"
+if [[ ${INPUT_EMPTYCOMMITS} == "true" ]]; then
+    git commit --allow-empty -m "${COMMIT_MESSAGE}"
 else
-    git commit -m "Automated deployment: $(date -u) ${GITHUB_SHA}" || true
+    git commit -m "${COMMIT_MESSAGE}" || true
 fi
 
 git push origin "${remote_branch}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,9 @@ COMMIT_MESSAGE="Automated deployment: $(date -u) ${GITHUB_SHA}"
 if [[ ${INPUT_EMPTYCOMMITS} == "true" ]]; then
     git commit --allow-empty -m "${COMMIT_MESSAGE}"
 else
-    git commit -m "${COMMIT_MESSAGE}" || true
+    git commit -m "${COMMIT_MESSAGE}" || \
+      print_info "No changes detected, skipping deployment" && \
+      exit 0
 fi
 
 git push origin "${remote_branch}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,8 +73,12 @@ git remote add origin "${remote_repo}"
 git add --all
 
 print_info "Allowing empty commits: ${INPUT_EMPTYCOMMITS}"
-[[ ${INPUT_EMPTYCOMMITS} == "true" ]] && params+=(--allow-empty) #optionally allow empty commits
-git commit "${params[@]}" -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+if [[ ${INPUT_EMPTYCOMMITS} == "true" ]]
+then
+    git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+else
+    git commit -m "Automated deployment: $(date -u) ${GITHUB_SHA}" || true
+fi
 
 git push origin "${remote_branch}"
 print_info "${GITHUB_SHA} was successfully deployed"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,10 @@ git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git remote rm origin || true
 git remote add origin "${remote_repo}"
 git add --all
-git commit --allow-empty -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+
+print_info "Allowing empty commits: ${INPUT_EMPTYCOMMITS}"
+[[ ${INPUT_EMPTYCOMMITS} == "true" ]] && params+=(--allow-empty) #optionally allow empty commits
+git commit "${params[@]}" -m "Automated deployment: $(date -u) ${GITHUB_SHA}"
+
 git push origin "${remote_branch}"
 print_info "${GITHUB_SHA} was successfully deployed"


### PR DESCRIPTION
Apparently it was easier than I anticipated. This should address #21.

I'm not sure if you wanted to standardize around `env` or using the `inputs/`with` feature. I went with `inputs` because it allowed for a more explicit default value if it is not provided, and at the end of the day I think it all gets exposed the same way.

I also played with doing a more consolidated change to the bash file (not using `if`), but this way seems cleaner when it comes to non-zero exit codes from `git commit`. 

I did test this with my own site, and confirmed it works as expected when making website changes, when making non-website changes, and when the parameter is not defined (as it will be for pretty much everyone using this once it's released).