### PR TITLE
Fix: "git rm" fails when publish branch is empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ remote_branch="${PUBLISH_BRANCH}"
 local_dir="${HOME}/$(tr -cd 'a-f0-9' < /dev/urandom | head -c 32)"
 if git clone --depth=1 --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
     cd "${local_dir}"
-    git rm -r '*'
+    git rm -r --ignore-unmatch '*'
     find "${GITHUB_WORKSPACE}/${PUBLISH_DIR}" -maxdepth 1 | \
         tail -n +2 | \
         xargs -I % cp -rf % "${local_dir}/"


### PR DESCRIPTION
When a publish branch exists and it has no files,
`git rm -r '*'` fails with
```
fatal: pathspec '*' did not match any files
```

[`--ignore-unmatch` option](https://git-scm.com/docs/git-rm#Documentation/git-rm.txt---ignore-unmatch) let git exit with a zero status in this case.