### PR TITLE
feat: new option keepFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,23 @@ For example:
     emptyCommits: false
 ```
 
+#### ⭐️ Keeping existing files
+
+By default, existing files in the publish branch are removed before adding the ones from publish dir. If you want the action to add new files but leave existing ones untouched, set the optional parameter `keepFiles` to `true`.
+
+For example:
+
+```yaml
+- name: deploy
+  uses: peaceiris/actions-gh-pages@v2.3.2
+  env:
+    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+    PUBLISH_BRANCH: gh-pages
+    PUBLISH_DIR: ./public
+  with:
+    keepFiles: true
+```
+
 
 ## Tips and FAQ
 

--- a/action.yml
+++ b/action.yml
@@ -12,3 +12,7 @@ inputs:
     description: 'If empty commits should be made to the publication branch'
     required: false
     default: 'true'
+  keepFiles:
+    description: 'If existing files in the publish branch should be not removed before deploying'
+    required: false
+    default: 'false'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,12 @@ remote_branch="${PUBLISH_BRANCH}"
 local_dir="${HOME}/$(tr -cd 'a-f0-9' < /dev/urandom | head -c 32)"
 if git clone --depth=1 --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
     cd "${local_dir}"
-    git rm -r --ignore-unmatch '*'
+
+    print_info "Keeping existing files: ${INPUT_KEEPFILES}"
+    if [[ ${INPUT_KEEPFILES} != "true" ]]; then
+        git rm -r --ignore-unmatch '*'
+    fi
+
     find "${GITHUB_WORKSPACE}/${PUBLISH_DIR}" -maxdepth 1 | \
         tail -n +2 | \
         xargs -I % cp -rf % "${local_dir}/"


### PR DESCRIPTION
There is a use cases when you need to only add new files to GitHub pages and do not remove existing. E.g. when you host different versions of some JS lib from GitHub pages.

This PR adds an option to support this use case. 