### PR TITLE
feat: deploy to other repo (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Table of Contents
     - [⭐️ `GITHUB_TOKEN`](#%EF%B8%8F-github_token)
     - [⭐️ Suppressing empty commits](#%EF%B8%8F-suppressing-empty-commits)
     - [⭐️ Keeping existing files](#%EF%B8%8F-keeping-existing-files)
-    - [⭐️ Publish to other repository](#%EF%B8%8F-publish-to-other-repository)
+    - [⭐️ Deploy to external repository](#%EF%B8%8F-deploy-to-external-repository)
 - [Tips and FAQ](#tips-and-faq)
   - [How to add `CNAME`](#how-to-add-cname)
   - [Deployment completed but you cannot read](#deployment-completed-but-you-cannot-read)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For example:
 
 #### ⭐️ Deploy to external repository
 
-By default, the files are published to the respository which is running this action. If you want to publish to another repository on GitHub set the environment variable `EXTERNAL_REPOSITORY` to `<username>/<repo>`.
+By default, your files are published to the repository which is running this action. If you want to publish to another repository on GitHub, set the environment variable `EXTERNAL_REPOSITORY` to `<username>/<external-repository>`.
 
 For example:
 
@@ -229,10 +229,16 @@ For example:
   uses: peaceiris/actions-gh-pages@v2.4.0
   env:
     ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-    EXTERNAL_REPOSITORY: peaceiris/peaceiris.github.io
+    EXTERNAL_REPOSITORY: username/username.github.io
     PUBLISH_BRANCH: master
     PUBLISH_DIR: ./public
 ```
+
+You can use `ACTIONS_DEPLOY_KEY` or `PERSONAL_TOKEN`. When you use `ACTIONS_DEPLOY_KEY`, set your private key to the repository which includes this action and set your public key to your external repository.
+
+Be careful, `GITHUB_TOKEN` has no permission to access to external repositories.
+
+
 
 ## Tips and FAQ
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Table of Contents
     - [⭐️ `GITHUB_TOKEN`](#%EF%B8%8F-github_token)
     - [⭐️ Suppressing empty commits](#%EF%B8%8F-suppressing-empty-commits)
     - [⭐️ Keeping existing files](#%EF%B8%8F-keeping-existing-files)
+    - [⭐️ Publish to other repository](#%EF%B8%8F-publish-to-other-repository)
 - [Tips and FAQ](#tips-and-faq)
   - [How to add `CNAME`](#how-to-add-cname)
   - [Deployment completed but you cannot read](#deployment-completed-but-you-cannot-read)
@@ -217,7 +218,21 @@ For example:
     keepFiles: true
 ```
 
+#### ⭐️ Publish to other repository
 
+By default, the files are published to the respository which is running this action. If you want to publish to another repository on GitHub set the environment variable `PUBLISH_REPO` to `<username>/<repo>`.
+
+For example:
+
+```yaml
+- name: Deploy
+  uses: peaceiris/actions-gh-pages@v2.4.0
+  env:
+    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+    PUBLISH_REPO: peaceiris/peaceiris.github.io
+    PUBLISH_BRANCH: master
+    PUBLISH_DIR: ./public
+```
 
 ## Tips and FAQ
 

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ For example:
     keepFiles: true
 ```
 
-#### ⭐️ Publish to other repository
+#### ⭐️ Deploy to external repository
 
-By default, the files are published to the respository which is running this action. If you want to publish to another repository on GitHub set the environment variable `PUBLISH_REPO` to `<username>/<repo>`.
+By default, the files are published to the respository which is running this action. If you want to publish to another repository on GitHub set the environment variable `EXTERNAL_REPOSITORY` to `<username>/<repo>`.
 
 For example:
 
@@ -229,7 +229,7 @@ For example:
   uses: peaceiris/actions-gh-pages@v2.4.0
   env:
     ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-    PUBLISH_REPO: peaceiris/peaceiris.github.io
+    EXTERNAL_REPOSITORY: peaceiris/peaceiris.github.io
     PUBLISH_BRANCH: master
     PUBLISH_DIR: ./public
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,7 @@ elif [ -n "${GITHUB_TOKEN}" ]; then
     if [ -n "${PUBLISH_REPO}" ]; then
         if [ "${GITHUB_REPOSITORY}" !=  "${PUBLISH_REPO}" ]; then
             echo "can not use GITHUB_TOKEN to deploy to a different repository"
+            exit 1
         fi
     fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,10 +17,12 @@ function skip() {
 }
 
 # check values
-if [ -z "${PUBLISH_REPOSITORY}" ]; then
-    print_info "setup with PUBLISH_REPOSITORY = GITHUB_REPOSITORY"
+if [ -n "${EXTERNAL_REPOSITORY}" ]; then
+    PUBLISH_REPOSITORY=${EXTERNAL_REPOSITORY}
+else
     PUBLISH_REPOSITORY=${GITHUB_REPOSITORY}
 fi
+print_info "Deploy to ${PUBLISH_REPOSITORY}"
 
 if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,9 +17,9 @@ function skip() {
 }
 
 # check values
-if [ -z "${PUBLISH_REPO}" ]; then
-    print_info "setup with PUBLISH_REPO = GITHUB_REPOSITORY"
-    PUBLISH_REPO=GITHUB_REPOSITORY
+if [ -z "${PUBLISH_REPOSITORY}" ]; then
+    print_info "setup with PUBLISH_REPOSITORY = GITHUB_REPOSITORY"
+    PUBLISH_REPOSITORY=${GITHUB_REPOSITORY}
 fi
 
 if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
@@ -31,23 +31,23 @@ if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
     echo "${ACTIONS_DEPLOY_KEY}" > /root/.ssh/id_rsa
     chmod 400 /root/.ssh/id_rsa
 
-    remote_repo="git@github.com:${PUBLISH_REPO}.git"
+    remote_repo="git@github.com:${PUBLISH_REPOSITORY}.git"
 
 elif [ -n "${PERSONAL_TOKEN}" ]; then
 
     print_info "setup with PERSONAL_TOKEN"
 
-    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${PUBLISH_REPO}.git"
+    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${PUBLISH_REPOSITORY}.git"
 
 elif [ -n "${GITHUB_TOKEN}" ]; then
 
     print_info "setup with GITHUB_TOKEN"
     print_error "Do not use GITHUB_TOKEN, See #9"
 
-    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUBLISH_REPO}.git"
+    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUBLISH_REPOSITORY}.git"
 
-    if [ -n "${PUBLISH_REPO}" ]; then
-        if [ "${GITHUB_REPOSITORY}" !=  "${PUBLISH_REPO}" ]; then
+    if [ -n "${PUBLISH_REPOSITORY}" ]; then
+        if [ "${GITHUB_REPOSITORY}" !=  "${PUBLISH_REPOSITORY}" ]; then
             echo "can not use GITHUB_TOKEN to deploy to a different repository"
             exit 1
         fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,11 @@ function skip() {
 }
 
 # check values
+if [ -z "${PUBLISH_REPO}" ]; then
+    print_info "setup with PUBLISH_REPO = GITHUB_REPOSITORY"
+    PUBLISH_REPO=GITHUB_REPOSITORY
+fi
+
 if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
 
     print_info "setup with ACTIONS_DEPLOY_KEY"
@@ -26,20 +31,26 @@ if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
     echo "${ACTIONS_DEPLOY_KEY}" > /root/.ssh/id_rsa
     chmod 400 /root/.ssh/id_rsa
 
-    remote_repo="git@github.com:${GITHUB_REPOSITORY}.git"
+    remote_repo="git@github.com:${PUBLISH_REPO}.git"
 
 elif [ -n "${PERSONAL_TOKEN}" ]; then
 
     print_info "setup with PERSONAL_TOKEN"
 
-    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${PUBLISH_REPO}.git"
 
 elif [ -n "${GITHUB_TOKEN}" ]; then
 
     print_info "setup with GITHUB_TOKEN"
     print_error "Do not use GITHUB_TOKEN, See #9"
 
-    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUBLISH_REPO}.git"
+
+    if [ -n "${PUBLISH_REPO}" ]; then
+        if [ "${GITHUB_REPOSITORY}" !=  "${PUBLISH_REPO}" ]; then
+            echo "can not use GITHUB_TOKEN to deploy to a different repository"
+        fi
+    fi
 
 else
     print_error "not found ACTIONS_DEPLOY_KEY, PERSONAL_TOKEN, or GITHUB_TOKEN"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,14 +46,12 @@ elif [ -n "${GITHUB_TOKEN}" ]; then
     print_info "setup with GITHUB_TOKEN"
     print_error "Do not use GITHUB_TOKEN, See #9"
 
-    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUBLISH_REPOSITORY}.git"
-
-    if [ -n "${PUBLISH_REPOSITORY}" ]; then
-        if [ "${GITHUB_REPOSITORY}" !=  "${PUBLISH_REPOSITORY}" ]; then
-            echo "can not use GITHUB_TOKEN to deploy to a different repository"
-            exit 1
-        fi
+    if [ -n "${EXTERNAL_REPOSITORY}" ]; then
+        print_error "can not use GITHUB_TOKEN to deploy to a external repository"
+        exit 1
     fi
+
+    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUBLISH_REPOSITORY}.git"
 
 else
     print_error "not found ACTIONS_DEPLOY_KEY, PERSONAL_TOKEN, or GITHUB_TOKEN"


### PR DESCRIPTION
⚠ I didn't test this yet!

This PR addresses #35 .

* I added a new environment variable `PUBLISH_REPO` (format: `<username>/<repo>`) which is used to build the `remote_repo` strings.
* If `PUBLISH_REPO` is not set it will be set and initialized with `GITHUB_REPOSITORY`.
* If `PUBLISH_REPO` is different from `GITHUB_REPOSITORY` and `GITHUB_TOKEN` is used an error message will be printed and the script exits (the `GITHUB_TOKEN` is scoped to the repository which runs the action).

Example how this can be used:

```yaml
- name: Deploy
  uses: peaceiris/actions-gh-pages@v2.4.0
  env:
    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
    PUBLISH_REPO: peaceiris/peaceiris.github.io
    PUBLISH_BRANCH: master
    PUBLISH_DIR: ./public
```

Any feedback is welcome 😊