### PR TITLE
[WIP] feat: Remove warning about GITHUB_TOKEN

### DIFF
--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -73,10 +73,8 @@ export async function setGithubToken(
   core.info('[INFO] setup GITHUB_TOKEN');
 
   const context = github.context;
-  const payload = github.context.payload;
   core.debug(`ref: ${context.ref}`);
   core.debug(`eventName: ${context.eventName}`);
-  core.debug(`private: ${payload.repository?.private}`);
   let isProhibitedBranch = false;
 
   const ref = context.ref;
@@ -89,15 +87,9 @@ export async function setGithubToken(
     }
   }
 
-  const isPrivateRepository = payload.repository?.private;
   if (inps.ExternalRepository) {
     throw new Error(
       'GITHUB_TOKEN does not support to push to an external repository'
-    );
-  }
-  if (isPrivateRepository === false) {
-    core.warning(
-      'GITHUB_TOKEN does not support to trigger the GitHub Pages build event on a public repository'
     );
   }
 


### PR DESCRIPTION
GitHub might have started to supporting to trigger the GitHub Pages build event by GITHUB_TOKEN on public repositories. (We can already use the token on private repositories.) Be careful, there is no official announcement about this by GitHub.

cf. #9