### PR TITLE
add remove_path_spec (default *) parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'If existing files in the publish branch should be not removed before deploying'
     required: false
     default: 'false'
+  remove_path_spec:
+    description: 'Git Pathspec that should be removed before deploying'
+    required: false
+    default: '*'
   force_orphan:
     description: 'Keep only the latest commit on a GitHub Pages branch'
     required: false

--- a/src/get-inputs.ts
+++ b/src/get-inputs.ts
@@ -18,6 +18,7 @@ export function showInputs(inps: Inputs): void {
 [INFO] ExternalRepository: ${inps.ExternalRepository}
 [INFO] AllowEmptyCommit: ${inps.AllowEmptyCommit}
 [INFO] KeepFiles: ${inps.KeepFiles}
+[INFO] RemovePathSpec: ${inps.RemovePathSpec}
 [INFO] ForceOrphan: ${inps.ForceOrphan}
 [INFO] UserName: ${inps.UserName}
 [INFO] UserEmail: ${inps.UserEmail}
@@ -57,6 +58,7 @@ export function getInputs(): Inputs {
       (core.getInput('allow_empty_commit') || 'false').toUpperCase() === 'TRUE',
     KeepFiles:
       (core.getInput('keep_files') || 'false').toUpperCase() === 'TRUE',
+    RemovePathSpec: core.getInput('remove_path_spec'),
     ForceOrphan:
       (core.getInput('force_orphan') || 'false').toUpperCase() === 'TRUE',
     UserName: core.getInput('user_name'),

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -81,7 +81,13 @@ export async function setRepo(
       if (inps.KeepFiles) {
         core.info('[INFO] Keep existing files');
       } else {
-        await exec.exec('git', ['rm', '-r', '--ignore-unmatch', '*']);
+        await exec.exec('git', [
+          'rm',
+          '-r',
+          '--ignore-unmatch',
+          '--',
+          ...inps.RemovePathSpec.split(',')
+        ]);
       }
 
       await copyAssets(publishDir, workDir);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface Inputs {
   readonly ExternalRepository: string;
   readonly AllowEmptyCommit: boolean;
   readonly KeepFiles: boolean;
+  readonly RemovePathSpec: string;
   readonly ForceOrphan: boolean;
   readonly UserName: string;
   readonly UserEmail: string;


### PR DESCRIPTION
closes #273 

adds a new parameter `remove_path_spec` that allows to customize the path spec(s) used for `git rm`