### PR TITLE
fix check order in setGithubToken

### DIFF
--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -70,15 +70,15 @@ export function setGithubToken(
   core.debug(`eventName: ${eventName}`);
   let isProhibitedBranch = false;
 
+  if (externalRepository) {
+    throw new Error('GITHUB_TOKEN does not support to push to an external repository');
+  }
+
   if (eventName === 'push') {
     isProhibitedBranch = ref.includes(`refs/heads/${publishBranch}`);
     if (isProhibitedBranch) {
       throw new Error(`You deploy from ${publishBranch} to ${publishBranch}`);
     }
-  }
-
-  if (externalRepository) {
-    throw new Error('GITHUB_TOKEN does not support to push to an external repository');
   }
 
   return `https://x-access-token:${githubToken}@github.com/${publishRepo}.git`;


### PR DESCRIPTION
In the current version, when trying to deploy to an external repository with
`github_token`, it fails with an inappropriate message.

Run workflow below:
```yaml
jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      # omitted
      - run: hugo
      - uses: peaceiris/actions-gh-pages@v3
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          external_repository: sarisia/external-repository
          publish_branch: master
          publish_dir: ./public
```

and get:
```
Setup auth token
  [INFO] setup GITHUB_TOKEN
  ##[error]Action failed with "You deploy from master to master"
```

I think this is inappropriate and difficult to identify the cause of failure, so
this PR changes check order in `setGithubToken()` to make error message more
intelligible.
