### PR TITLE
Allow absolute paths for publish_dir

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -29,7 +29,9 @@ export async function copyAssets(publishDir: string, workDir: string): Promise<v
 }
 
 export async function setRepo(inps: Inputs, remoteURL: string, workDir: string): Promise<void> {
-  const publishDir = path.join(`${process.env.GITHUB_WORKSPACE}`, inps.PublishDir);
+  const publishDir = path.isAbsolute(inps.PublishDir)
+    ? inps.PublishDir
+    : path.join(`${process.env.GITHUB_WORKSPACE}`, inps.PublishDir);
 
   core.info(`[INFO] ForceOrphan: ${inps.ForceOrphan}`);
   if (inps.ForceOrphan) {


### PR DESCRIPTION
Thanks for your great work. I have a use case where the tool to find the generated documentation is returning an absolute path. Instead of trying to calculate the relative paths by myself, I feel we can support absolute paths instead. This seems to be an easy change so I just made a PR. Please feel free to commit any further changes to this branch. This will close #242.