### PR TITLE
Fix deployment problems with destionationDir set

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -22,6 +22,10 @@ export async function copyAssets(publishDir: string, destDir: string): Promise<v
     }
     const filePublishPath = path.join(publishDir, file);
     const fileDestPath = path.join(destDir, file);
+    const destPath = path.dirname(fileDestPath);
+    if (fs.existsSync(destPath) === false) {
+      await createDir(destPath);
+    }
     await io.cp(filePublishPath, fileDestPath, copyOpts);
     core.info(`[INFO] copy ${file}`);
   }


### PR DESCRIPTION
This fixes #410 

The destination directory is not getting created using `fs.copyFileSync` (which is used in `io.cp`), so the code has to take care of that.