### PR TITLE
ci: allow dependency-type production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,8 @@ updates:
     timezone: Japan
   labels:
   - dependencies
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - ">= 13.a, < 14"
-    - ">= 14.a, < 15"
+  allow:
+  - dependency-type: "production"
   commit-message:
     prefix: deps
 


### PR DESCRIPTION
[Configuration options for dependency updates - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow)