### PR TITLE
Add create-react-app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,50 @@ jobs:
           publish_dir: ./public
 ```
 
+### ⭐️ React with Create React App
+
+An example for [React] (React.js) project with [create-react-app]
+
+[React]: https://reactjs.org/
+[create-react-app]: https://github.com/facebook/create-react-app
+
+```yaml
+name: github pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: '12.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+```
+
 ### ⭐️ React and Next
 
 An example for [Next.js] (React.js) project with [create-next-app]

--- a/README.md
+++ b/README.md
@@ -596,12 +596,13 @@ jobs:
 
 ### ⭐️ Static Site Generators with Node.js
 
-[hexo], [vuepress], [react-static], [gridsome], and so on.
+[hexo], [vuepress], [react-static], [gridsome], [create-react-app] and so on. Create react app requires `publish_dir` to be set to `./build`
 
 [hexo]: https://github.com/hexojs/hexo
 [vuepress]: https://github.com/vuejs/vuepress
 [react-static]: https://github.com/react-static/react-static
 [gridsome]: https://github.com/gridsome/gridsome
+[create-react-app]: https://github.com/facebook/create-react-app
 
 Premise: Dependencies are managed by `package.json` and `package-lock.json`
 
@@ -686,50 +687,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-```
-
-### ⭐️ React with Create React App
-
-An example for [React] (React.js) project with [create-react-app]
-
-[React]: https://reactjs.org/
-[create-react-app]: https://github.com/facebook/create-react-app
-
-```yaml
-name: github pages
-
-on:
-  push:
-    branches:
-      - main
-
-jobs:
-  deploy:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v2.1.0
-        with:
-          node-version: '12.x'
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - run: npm ci
-      - run: npm run build
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
 ```
 
 ### ⭐️ React and Next

--- a/README.md
+++ b/README.md
@@ -596,7 +596,9 @@ jobs:
 
 ### ⭐️ Static Site Generators with Node.js
 
-[hexo], [vuepress], [react-static], [gridsome], [create-react-app] and so on. Create react app requires `publish_dir` to be set to `./build`
+[hexo], [vuepress], [react-static], [gridsome], [create-react-app] and so on.
+Please check where your output directory is before pushing your workflow.
+e.g. `create-react-app` requires `publish_dir` to be set to `./build`
 
 [hexo]: https://github.com/hexojs/hexo
 [vuepress]: https://github.com/vuejs/vuepress


### PR DESCRIPTION
Added a create-react-app example in case anyone is wondering how to use it with `actions-gh-pages`. It differs slightly from `Static Site Generators with Node.js`.