### PR TITLE
ci: use certain OS version instead of latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           - 'ubuntu-20.04'
           - 'ubuntu-18.04'
           - 'ubuntu-16.04'
-          - 'macos-latest'
-          - 'windows-latest'
+          - 'macos-10.15'  # macos-latest
+          - 'windows-2019' # windows-latest
     steps:
       - uses: actions/checkout@v2.3.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - 'ubuntu-20.04'
           - 'ubuntu-18.04'
           - 'ubuntu-16.04'
+          - 'macos-11.0'
           - 'macos-10.15'  # macos-latest
           - 'windows-2019' # windows-latest
     steps:


### PR DESCRIPTION
- [x] ci: Change macos-latest to macos-10.15
- [x] ci: Change windows-latest to windows-2019
- [x] ci: Add macos-11.0 (macOS Big Sur 11.0)
- [ ] docs: Add macos-11.0 (macOS Big Sur 11.0)
- [ ] ci: Add deploy step for macos-11.0 (macOS Big Sur 11.0)

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on