### PR TITLE
deps: bump node from 12 to 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,7 @@ jobs:
 
       - name: Deploy
         if: |
-          startsWith(matrix.os, 'ubuntu-18.04') &&
-          github.ref == 'refs/heads/main'
+          startsWith(matrix.os, 'ubuntu-18.04')
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'GitHub Pages action'
 description: 'GitHub Actions for GitHub Pages 🚀 Deploy static files and publish your site easily. Static-Site-Generators-friendly.'
 author: 'peaceiris'
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'lib/index.js'
 branding:
   icon: 'upload-cloud'


### PR DESCRIPTION
Related to https://github.com/actions/runner/issues/772

> https://github.com/peaceiris/actions-gh-pages/pull/539/checks?check_run_id=1437553870#step:19:20
> Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node14' is not supported, use 'docker' or 'node12' instead.')