### PR TITLE
ci: remove CODECOV_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
           path: coverage
 
       - uses: codecov/codecov-action@v1.1.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run ncc
         run: npm run build


### PR DESCRIPTION
> For public repositories, no token is needed

https://github.com/codecov/codecov-action