### PR TITLE
ci: Exclude writing actions on forks

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -43,4 +43,4 @@ jobs:
       - run: make ci
       - run: make all
       - run: docker-compose push
-        if: github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+        if: github.ref == 'refs/heads/main' && github.event.repository.fork == false

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -43,4 +43,4 @@ jobs:
       - run: make ci
       - run: make all
       - run: docker-compose push
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-18.04') &&
-          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -117,7 +117,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-16.04') &&
-          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -135,7 +135,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'macos') &&
-          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -154,7 +154,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'windows') &&
-          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -173,7 +173,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-20.04') &&
-          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-18.04') &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -117,7 +117,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-16.04') &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
         uses: ./
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -135,7 +135,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'macos') &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
         uses: ./
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -154,7 +154,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'windows') &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -173,7 +173,7 @@ jobs:
       - name: Deploy
         if: |
           startsWith(matrix.os, 'ubuntu-20.04') &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' && github.repository_owner == 'peaceiris'
         uses: ./
         with:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
This will let people who forked this repository run CI without seeing misleading failures.