### PR TITLE
Do not include `.` and `..` in assets

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -57,7 +57,7 @@ export async function copyAssets(
   }
 
   core.info(`[INFO] copy ${publishDir} to ${destDir}`);
-  cp('-RfL', [`${publishDir}/*`, `${publishDir}/.*`], destDir);
+  cp('-RfLT', publishDir, destDir);
 
   await deleteExcludedAssets(destDir, excludeAssets);
 


### PR DESCRIPTION
Copying `cp -R ${publishDir}/.* ${destDir}` will include the special
files `.` and `..` and lead to unexpected results. Instead use the
`--no-target-directory` command line argument and drop the second
source.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>