### PR TITLE
fix: use custom path & random filename for ssh auth socket

### DIFF
--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -59,8 +59,9 @@ Watch https://github.com/peaceiris/actions-gh-pages/issues/87
     await exec.exec('sc', ['config', 'ssh-agent', 'start=auto']);
     await exec.exec('sc', ['start', 'ssh-agent']);
   }
-  await cpexec('ssh-agent', ['-a', '/tmp/ssh-auth.actions-gh-pages.sock']);
-  core.exportVariable('SSH_AUTH_SOCK', '/tmp/ssh-auth.actions-gh-pages.sock');
+  const socketPath = `/tmp/ssh-auth.actions-gh-pages.${Math.random().toString().slice(2)}.sock`;
+  await cpexec('ssh-agent', ['-a', socketPath]);
+  core.exportVariable('SSH_AUTH_SOCK', socketPath);
   await exec.exec('ssh-add', [idRSA]);
 
   return `git@${getServerUrl().host}:${publishRepo}.git`;

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -60,6 +60,7 @@ Watch https://github.com/peaceiris/actions-gh-pages/issues/87
     await exec.exec('sc', ['start', 'ssh-agent']);
   }
   const socketPath = `/tmp/ssh-auth.actions-gh-pages.${Math.random().toString().slice(2)}.sock`;
+  core.info(`[INFO] acquiring socket with path: ${socketPath}`);
   await cpexec('ssh-agent', ['-a', socketPath]);
   core.exportVariable('SSH_AUTH_SOCK', socketPath);
   await exec.exec('ssh-add', [idRSA]);

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -59,8 +59,8 @@ Watch https://github.com/peaceiris/actions-gh-pages/issues/87
     await exec.exec('sc', ['config', 'ssh-agent', 'start=auto']);
     await exec.exec('sc', ['start', 'ssh-agent']);
   }
-  await cpexec('ssh-agent', ['-a', '/tmp/ssh-auth.sock']);
-  core.exportVariable('SSH_AUTH_SOCK', '/tmp/ssh-auth.sock');
+  await cpexec('ssh-agent', ['-a', '/tmp/ssh-auth.actions-gh-pages.sock']);
+  core.exportVariable('SSH_AUTH_SOCK', '/tmp/ssh-auth.actions-gh-pages.sock');
   await exec.exec('ssh-add', [idRSA]);
 
   return `git@${getServerUrl().host}:${publishRepo}.git`;


### PR DESCRIPTION
github action runners can be self-hosted. i am running one inside my server.

turns out, the github action cannot just assume that it's the only one who's using
the server's infrastructure.

this should help w/ the ssh stuff.
fyi, i am not sure 100% if this fixes it:
i tried running the commands here and it helped,
but not sure if it i'll be the case when the action does so, but should be good.

for _not_ overriding the .ssh/config,
for _not_ spamming the .ssh/known_hosts file,

i'll consider creating separate PRs.

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>