### PR TITLE
Allow GHES support to auth using deploy key

### DIFF
--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -22,13 +22,18 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
 
   const knownHosts = path.join(sshDir, 'known_hosts');
   // ssh-keyscan -t rsa github.com or serverUrl >> ~/.ssh/known_hosts on Ubuntu
-  const cmdSSHkeyscanOutput = `\
-# ${getServerUrl().host}.com:22 SSH-2.0-babeld-1f0633a6
-${
-  getServerUrl().host
-} ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+  const defaultGithubSSHkeyscanOutput = `\
+# github.com:22 SSH-2.0-babeld-1f0633a6
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 `;
-  fs.writeFileSync(knownHosts, cmdSSHkeyscanOutput + '\n');
+
+  const keyscanOutput = await exec.getExecOutput('ssh-keyscan', ['-t', 'rsa', getServerUrl().host]);
+  const sshKeyscanOutputString =
+    keyscanOutput.exitCode === 0
+      ? keyscanOutput.stderr + keyscanOutput.stdout
+      : defaultGithubSSHkeyscanOutput;
+
+  fs.writeFileSync(knownHosts, sshKeyscanOutputString);
   core.info(`[INFO] wrote ${knownHosts}`);
   await exec.exec('chmod', ['600', knownHosts]);
 

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -21,19 +21,21 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
   await exec.exec('chmod', ['700', sshDir]);
 
   const knownHosts = path.join(sshDir, 'known_hosts');
+
   // ssh-keyscan -t rsa github.com or serverUrl >> ~/.ssh/known_hosts on Ubuntu
-  const defaultGithubSSHkeyscanOutput = `\
+  const foundKnownHostKey = await (async () => {
+    try {
+      return (await exec.getExecOutput('ssh-keyscan', ['-t', 'rsa', getServerUrl().host, '&>']))
+        .stdout;
+    } catch (e) {
+      return `\
 # github.com:22 SSH-2.0-babeld-1f0633a6
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 `;
+    }
+  })();
 
-  const keyscanOutput = await exec.getExecOutput('ssh-keyscan', ['-t', 'rsa', getServerUrl().host]);
-  const sshKeyscanOutputString =
-    keyscanOutput.exitCode === 0
-      ? keyscanOutput.stderr + keyscanOutput.stdout
-      : defaultGithubSSHkeyscanOutput;
-
-  fs.writeFileSync(knownHosts, sshKeyscanOutputString);
+  fs.writeFileSync(knownHosts, foundKnownHostKey);
   core.info(`[INFO] wrote ${knownHosts}`);
   await exec.exec('chmod', ['600', knownHosts]);
 


### PR DESCRIPTION
This PR is to support GHES deployment using its deploy key. Tested with the GHES server with self-hosted runners, and github.com. You can test it by using `uses: jiminj/actions-gh-pages@v3.8.1-0`
