### PR TITLE
Allow GHES repository to support deploy key

### DIFF
--- a/__tests__/set-tokens.test.ts
+++ b/__tests__/set-tokens.test.ts
@@ -1,4 +1,26 @@
-import {getPublishRepo, setPersonalToken, setGithubToken} from '../src/set-tokens';
+import {getPublishRepo, setPersonalToken, setGithubToken, setSSHKey} from '../src/set-tokens';
+import {Inputs} from '../src/interfaces';
+
+import fs from 'fs';
+import * as exec from '@actions/exec';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as core from '@actions/core';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as io from '@actions/io';
+
+jest.mock('@actions/exec', () => ({
+  exec: jest.fn(),
+  getExecOutput: jest.fn().mockReturnValue({
+    stdout: 'hostinfo',
+    exitCode: 0
+  })
+}));
+jest.mock('@actions/io', () => ({
+  mkdirP: jest.fn()
+}));
+jest.mock('@actions/core');
+jest.mock('fs');
+jest.mock('child_process');
 
 beforeEach(() => {
   jest.resetModules();
@@ -7,6 +29,64 @@ beforeEach(() => {
 // afterEach(() => {
 
 // });
+
+describe('setSSHKey()', () => {
+  const createInputs = (): Inputs => ({
+    DeployKey: 'DEPLOY_KEY',
+    GithubToken: '',
+    PersonalToken: '',
+    PublishBranch: 'gh-pages',
+    PublishDir: '',
+    DestinationDir: '',
+    ExternalRepository: '',
+    AllowEmptyCommit: false,
+    KeepFiles: false,
+    ForceOrphan: false,
+    UserName: '',
+    UserEmail: '',
+    CommitMessage: '',
+    FullCommitMessage: '',
+    TagName: '',
+    TagMessage: '',
+    DisableNoJekyll: false,
+    CNAME: '',
+    ExcludeAssets: ''
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('return correct repo address', async () => {
+    const inps: Inputs = createInputs();
+    const test = await setSSHKey(inps, 'owner/repo');
+    expect(test).toMatch('git@github.com:owner/repo.git');
+  });
+
+  test('set known_hosts with the ssh-keyscan output if it succeeded', async () => {
+    const inps: Inputs = createInputs();
+    await setSSHKey(inps, 'owner/repo');
+
+    const mockGetExecOutput = await exec.getExecOutput('');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('known_hosts'),
+      mockGetExecOutput.stdout
+    );
+  });
+
+  test('SSH key fallbacks to default value if ssh-keyscan fails', async () => {
+    const inps: Inputs = createInputs();
+    (exec.getExecOutput as jest.Mock).mockImplementation(() => {
+      throw new Error('error');
+    });
+
+    await setSSHKey(inps, 'owner/repo');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('known_hosts'),
+      expect.stringContaining('# github.com:22 SSH-2.0-babeld-1f0633a6')
+    );
+  });
+});
 
 describe('getPublishRepo()', () => {
   test('return repository name', () => {

--- a/__tests__/set-tokens.test.ts
+++ b/__tests__/set-tokens.test.ts
@@ -11,6 +11,7 @@ import * as io from '@actions/io';
 jest.mock('@actions/exec', () => ({
   exec: jest.fn(),
   getExecOutput: jest.fn().mockReturnValue({
+    stderr: '# hostname',
     stdout: 'hostinfo',
     exitCode: 0
   })
@@ -70,7 +71,7 @@ describe('setSSHKey()', () => {
     const mockGetExecOutput = await exec.getExecOutput('');
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('known_hosts'),
-      mockGetExecOutput.stdout
+      mockGetExecOutput.stderr + mockGetExecOutput.stdout
     );
   });
 

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -25,8 +25,12 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
   // ssh-keyscan -t rsa github.com or serverUrl >> ~/.ssh/known_hosts on Ubuntu
   const foundKnownHostKey = await (async () => {
     try {
-      return (await exec.getExecOutput('ssh-keyscan', ['-t', 'rsa', getServerUrl().host, '&>']))
-        .stdout;
+      const keyscanOutput = await exec.getExecOutput('ssh-keyscan', [
+        '-t',
+        'rsa',
+        getServerUrl().host
+      ]);
+      return keyscanOutput.stderr + keyscanOutput.stdout;
     } catch (e) {
       return `\
 # github.com:22 SSH-2.0-babeld-1f0633a6

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -21,14 +21,21 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
   await exec.exec('chmod', ['700', sshDir]);
 
   const knownHosts = path.join(sshDir, 'known_hosts');
+
   // ssh-keyscan -t rsa github.com or serverUrl >> ~/.ssh/known_hosts on Ubuntu
-  const cmdSSHkeyscanOutput = `\
-# ${getServerUrl().host}.com:22 SSH-2.0-babeld-1f0633a6
-${
-  getServerUrl().host
-} ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+  const foundKnownHostKey = await (async () => {
+    try {
+      return (await exec.getExecOutput('ssh-keyscan', ['-t', 'rsa', getServerUrl().host, '&>']))
+        .stdout;
+    } catch (e) {
+      return `\
+# github.com:22 SSH-2.0-babeld-1f0633a6
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 `;
-  fs.writeFileSync(knownHosts, cmdSSHkeyscanOutput + '\n');
+    }
+  })();
+
+  fs.writeFileSync(knownHosts, foundKnownHostKey);
   core.info(`[INFO] wrote ${knownHosts}`);
   await exec.exec('chmod', ['600', knownHosts]);
 


### PR DESCRIPTION
This PR is a revision of #679, allowing to deploy on GHES repositories using deploy keys.  - Found that simple error code checking does not handle the case when `ssh-keyscan` is failed. this PR includes the updated logic and corresponding test codes.

Tested with the GHES server with self-hosted runners, and github.com. You can test it by using `uses: jiminj/actions-gh-pages@v3.8.1-0`