### PR TITLE
Add git-lfs to setup process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ trim_trailing_whitespace = true
 [Makefile]
 indent_size = 4
 indent_style = tab
+
+[Dockerfile]
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
     curl \
     wget \
     ssh \
-    git-lfs \
     vim && \
     apt-get autoclean && \
     apt-get clean && \
@@ -20,8 +19,7 @@ RUN apt-get update && \
 
 RUN git --version && \
     git config --global init.defaultBranch main && \
-    git config --global init.defaultBranch && \
-    git lfs install
+    git config --global init.defaultBranch
 
 WORKDIR /node
 ARG NODE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     curl \
     wget \
     ssh \
+    git-lfs \
     vim && \
     apt-get autoclean && \
     apt-get clean && \
@@ -19,7 +20,8 @@ RUN apt-get update && \
 
 RUN git --version && \
     git config --global init.defaultBranch main && \
-    git config --global init.defaultBranch
+    git config --global init.defaultBranch && \
+    git lfs install
 
 WORKDIR /node
 ARG NODE_VERSION

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Note that the `GITHUB_TOKEN` that is created by the runner might not inherently 
   - [⭐️ Set Git username and email](#%EF%B8%8F-set-git-username-and-email)
   - [⭐️ Set custom commit message](#%EF%B8%8F-set-custom-commit-message)
   - [⭐️ Create Git tag](#%EF%B8%8F-create-git-tag)
+  - [⭐️ Upload large files with Git LFS](#%EF%B8%8F-upload-large-files-with-git-lfs)
 - [Tips and FAQ](#tips-and-faq)
   - [⭐️ Create SSH Deploy Key](#%EF%B8%8F-create-ssh-deploy-key)
   - [⭐️ First Deployment with `GITHUB_TOKEN`](#%EF%B8%8F-first-deployment-with-github_token)
@@ -523,7 +524,44 @@ v1.2.3         # Tag on the main branch
 <a href="#table-of-contents">Back to TOC ☝️</a>
 </div>
 
+### ⭐️ Upload large files with Git LFS
 
+If you are using [Git LFS](https://git-lfs.github.com/) as an option to manage files larger than 100MB in your repository, you can push these to the deployed site.
+
+It is expected that you would run your checkout action with `lfs` enabled (see below for an example).
+
+You will also need to make sure that your build tool includes the `.gitattributes` file in its output.
+
+```yaml
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - name: Checkout
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          lfs: 'true'
+```
 
 ## Tips and FAQ
 

--- a/__tests__/get-inputs.test.ts
+++ b/__tests__/get-inputs.test.ts
@@ -56,6 +56,7 @@ function getInputsLog(authMethod: string, inps: Inputs): string {
 [INFO] EnableJekyll (DisableNoJekyll): ${inps.DisableNoJekyll}
 [INFO] CNAME: ${inps.CNAME}
 [INFO] ExcludeAssets ${inps.ExcludeAssets}
+[INFO] Lfs: ${inps.Lfs}
 `;
 }
 
@@ -125,6 +126,7 @@ describe('getInputs()', () => {
     expect(inps.DisableNoJekyll).toBe(false);
     expect(inps.CNAME).toMatch('');
     expect(inps.ExcludeAssets).toMatch('.github');
+    expect(inps.Lfs).toBe(false);
   });
 
   test('get spec inputs', () => {
@@ -147,6 +149,7 @@ describe('getInputs()', () => {
     process.env['INPUT_DISABLE_NOJEKYLL'] = 'true';
     process.env['INPUT_CNAME'] = 'github.com';
     process.env['INPUT_EXCLUDE_ASSETS'] = '.github';
+    process.env['INPUT_LFS'] = 'false';
 
     const inps: Inputs = getInputs();
 
@@ -169,6 +172,7 @@ describe('getInputs()', () => {
     expect(inps.DisableNoJekyll).toBe(true);
     expect(inps.CNAME).toMatch('github.com');
     expect(inps.ExcludeAssets).toMatch('.github');
+    expect(inps.Lfs).toBe(false);
   });
 
   test('get spec inputs enable_jekyll', () => {

--- a/action.yml
+++ b/action.yml
@@ -77,3 +77,7 @@ inputs:
     description: 'Set files or directories to exclude from a publish directory.'
     required: false
     default: '.github'
+  lfs:
+    description: 'Whether to use Git-LFS to upload files'
+    required: false
+    default: 'false'

--- a/src/get-inputs.ts
+++ b/src/get-inputs.ts
@@ -29,6 +29,7 @@ export function showInputs(inps: Inputs): void {
 [INFO] EnableJekyll (DisableNoJekyll): ${inps.DisableNoJekyll}
 [INFO] CNAME: ${inps.CNAME}
 [INFO] ExcludeAssets ${inps.ExcludeAssets}
+[INFO] Lfs: ${inps.Lfs}
 `);
 }
 
@@ -48,9 +49,12 @@ export function getInputs(): Inputs {
     useBuiltinJekyll = true;
   }
 
+  const enableLfs: boolean = isBoolean(core.getInput('lfs'));
+
   const inps: Inputs = {
     DeployKey: core.getInput('deploy_key'),
     GithubToken: core.getInput('github_token'),
+    Lfs: enableLfs,
     PersonalToken: core.getInput('personal_token'),
     PublishBranch: core.getInput('publish_branch'),
     PublishDir: core.getInput('publish_dir'),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,7 @@
 export interface Inputs {
   readonly DeployKey: string;
   readonly GithubToken: string;
+  readonly Lfs: boolean;
   readonly PersonalToken: string;
   readonly PublishBranch: string;
   readonly PublishDir: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,9 @@ export async function run(): Promise<void> {
     core.endGroup();
 
     core.startGroup('Setup Git config');
+    if (inps.Lfs) {
+      await exec.exec('git', ['lfs', 'install', '--local']);
+    }
     try {
       await exec.exec('git', ['remote', 'rm', 'origin']);
     } catch (e) {


### PR DESCRIPTION
This PR will add the installation of [git-lfs](https://git-lfs.github.com/) to the container and initiate it during the initial setup of git during the RUN phase, allowing the container to handle the use of large files pushed to the Github Pages site and branch.  

This addresses #748 by applying the right machine-level systems but does not completely solve the problem, as the user will still need to find a way to pass their `.gitattributes` file to the base of their new site the same way they might need to with a `CNAME` file. 