### PR TITLE
Improve custom branch clarity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        # If you're changing the branch from main, 
+        # also change the `main` in `refs/heads/main` 
+        # below accordingly.
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By default, I run `git push origin master` instead of `git push origin main` when first creating a repository, so I didn't realize why my deploy step was being skipped, until I realized that `refs/heads/main` should also be changed to `refs/heads/master` when changing the default branch. 

Below, I added 3 lines of comments explaining to the user that they should also modify the `refs/heads/...` portion of the code when changing the default branch 

I think that this change would help people that are copy pasting the code to try to get the example to work, so they know what values to change when modifying their branch.