### PR TITLE
ci: drop ubuntu-18.04, add 22.04, latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   CodeQL-Build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/dependency-review-action@v2

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   dev-image-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Login to Packages

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   comment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/labeler@v4
       with:

--- a/.github/workflows/pages-status-check.yml
+++ b/.github/workflows/pages-status-check.yml
@@ -4,7 +4,7 @@ on: page_build
 
 jobs:
   pages-status-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: check status
         run: |

--- a/.github/workflows/purge-readme-image-cache.yml
+++ b/.github/workflows/purge-readme-image-cache.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   purge:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
     - run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # https://github.com/peaceiris/workflows/blob/main/create-release-npm/action.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'ubuntu-22.04'
           - 'ubuntu-20.04'
-          - 'ubuntu-18.04'
+          - 'ubuntu-latest'
           - 'macos-latest'
           - 'windows-latest'
     permissions:
@@ -51,7 +52,7 @@ jobs:
       - run: npm ci --ignore-scripts
 
       - name: npm audit
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: |
           npm audit > ./audit.log || true
           if ! [ "$(cat ./audit.log | wc -l)" = 1 ]; then
@@ -60,11 +61,11 @@ jobs:
           rm ./audit.log
 
       - name: Run prettier
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: npm run format:check
 
       - name: Run eslint
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: npm run lint
 
       - run: npm test
@@ -99,7 +100,7 @@ jobs:
 
       - name: Deploy
         if: |
-          startsWith(matrix.os, 'ubuntu-18.04') &&
+          startsWith(matrix.os, 'ubuntu-latest') &&
           github.ref == 'refs/heads/main' && github.event.repository.fork == false
         uses: ./
         with:
@@ -163,6 +164,24 @@ jobs:
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages-ubuntu-20.04
+          publish_dir: ./test_projects/mdbook/book
+          # external_repository: ''
+          allow_empty_commit: true
+          # keep_files: true
+          # force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          # commit_message: ${{ github.event.head_commit.message }}
+
+      - name: Deploy
+        if: |
+          startsWith(matrix.os, 'ubuntu-22.04') &&
+          github.ref == 'refs/heads/main' && github.event.repository.fork == false
+        uses: ./
+        with:
+          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages-ubuntu-22.04
           publish_dir: ./test_projects/mdbook/book
           # external_repository: ''
           allow_empty_commit: true

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ All Actions runners: Linux (Ubuntu), macOS, and Windows are supported.
 
 | runs-on | `github_token` | `deploy_key` | `personal_token` |
 |---|:---:|:---:|:---:|
+| ubuntu-22.04 | ✅️ | ✅️ | ✅️ |
 | ubuntu-20.04 | ✅️ | ✅️ | ✅️ |
-| ubuntu-18.04 | ✅️ | ✅️ | ✅️ |
+| ubuntu-latest | ✅️ | ✅️ | ✅️ |
 | macos-latest | ✅️ | ✅️ | ✅️ |
 | windows-latest | ✅️ | (2) | ✅️ |
 
@@ -149,7 +150,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -170,8 +171,8 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # If you're changing the branch from main, 
-        # also change the `main` in `refs/heads/main` 
+        # If you're changing the branch from main,
+        # also change the `main` in `refs/heads/main`
         # below accordingly.
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
@@ -489,7 +490,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -641,7 +642,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -683,7 +684,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -733,7 +734,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -785,7 +786,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -842,7 +843,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -897,7 +898,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -957,7 +958,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -1019,7 +1020,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -1064,7 +1065,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:
@@ -1110,7 +1111,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:


### PR DESCRIPTION
- [starting with 8 of August 2022 support for ubuntu 18.04 is deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)
- [ubuntu 22.04 is generally available](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/)

---
This PR was made as a part of blog post [The strongest principle of the blog's growth lies in the human choice to deploy it](https://dev.to/imomaliev/the-strongest-principle-of-the-blogs-growth-lies-in-the-human-choice-to-deploy-it-3ed9)