### PR TITLE
docs: hugo-version 0.85.0 -> 0.87.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.85.0'
+          hugo-version: '0.87.0'
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
## Is your feature request related to a problem? Please describe

I am using the [Hugo theme(Toha)](https://github.com/hugo-toha/toha) and reproduced the following problem.

It is a bug that the posting date is displayed as ":date_full"
<img width="414" alt="pic_01" src="https://user-images.githubusercontent.com/47747828/188319395-028aed83-3eb8-4010-8547-8984efe9dd65.png">

https://github.com/hugo-toha/toha/issues/531

## Describe the solution you'd like

- The bug has been fixed in Hugo v0.87.0, so I would like to change the version of this repository from v0.85.0 to v0.87.0.
(Resolved in my environment.)

[Hugo v0.87.0 - Release Note](https://github.com/gohugoio/hugo/releases?q=0.87)