### PR TITLE
feat: Add cleanup_work_dir option (#697, #686)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Note that the `GITHUB_TOKEN` that is created by the runner might not inherently 
   - [⭐️ Set Git username and email](#%EF%B8%8F-set-git-username-and-email)
   - [⭐️ Set custom commit message](#%EF%B8%8F-set-custom-commit-message)
   - [⭐️ Create Git tag](#%EF%B8%8F-create-git-tag)
+  - [⭐️ Clean up a working directory `cleanup_work_dir`](#%EF%B8%8F-clean-up-a-working-directory-cleanup_work_dir)
 - [Tips and FAQ](#tips-and-faq)
   - [⭐️ Create SSH Deploy Key](#%EF%B8%8F-create-ssh-deploy-key)
   - [⭐️ First Deployment with `GITHUB_TOKEN`](#%EF%B8%8F-first-deployment-with-github_token)
@@ -527,6 +528,19 @@ $ git fetch origin
 $ git tag
 deploy-v1.2.3  # Tag on the gh-pages branch
 v1.2.3         # Tag on the main branch
+```
+
+### ⭐️ Clean up a working directory `cleanup_work_dir`
+We can set the `cleanup_work_dir: true` option.
+This allows you to delete a working directory (`$HOME/actions_github_pages_{unixTime}`).
+
+```yaml
+- name: Deploy
+  uses: peaceiris/actions-gh-pages@v3
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    publish_dir: ./public
+    cleanup_work_dir: true
 ```
 
 <div align="right">

--- a/__tests__/get-inputs.test.ts
+++ b/__tests__/get-inputs.test.ts
@@ -56,6 +56,7 @@ function getInputsLog(authMethod: string, inps: Inputs): string {
 [INFO] EnableJekyll (DisableNoJekyll): ${inps.DisableNoJekyll}
 [INFO] CNAME: ${inps.CNAME}
 [INFO] ExcludeAssets ${inps.ExcludeAssets}
+[INFO] CleanupWorkDir: ${inps.CleanupWorkDir}
 `;
 }
 
@@ -125,6 +126,7 @@ describe('getInputs()', () => {
     expect(inps.DisableNoJekyll).toBe(false);
     expect(inps.CNAME).toMatch('');
     expect(inps.ExcludeAssets).toMatch('.github');
+    expect(inps.CleanupWorkDir).toBe(false);
   });
 
   test('get spec inputs', () => {
@@ -147,6 +149,7 @@ describe('getInputs()', () => {
     process.env['INPUT_DISABLE_NOJEKYLL'] = 'true';
     process.env['INPUT_CNAME'] = 'github.com';
     process.env['INPUT_EXCLUDE_ASSETS'] = '.github';
+    process.env['INPUT_CLEANUP_WORK_DIR'] = 'false';
 
     const inps: Inputs = getInputs();
 
@@ -169,6 +172,7 @@ describe('getInputs()', () => {
     expect(inps.DisableNoJekyll).toBe(true);
     expect(inps.CNAME).toMatch('github.com');
     expect(inps.ExcludeAssets).toMatch('.github');
+    expect(inps.CleanupWorkDir).toBe(false);
   });
 
   test('get spec inputs enable_jekyll', () => {

--- a/__tests__/get-inputs.test.ts
+++ b/__tests__/get-inputs.test.ts
@@ -188,6 +188,6 @@ describe('getInputs()', () => {
 
     expect(() => {
       getInputs();
-    }).toThrowError('Use either of enable_jekyll or disable_nojekyll');
+    }).toThrow('Use either of enable_jekyll or disable_nojekyll');
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getHomeDir,
   getWorkDirName,
   createDir,
+  deleteDir,
   addNoJekyll,
   addCNAME,
   skipOnFork
@@ -58,6 +59,17 @@ describe('createDir()', () => {
     await createDir(workDirName);
     const test = fs.existsSync(workDirName);
     expect(test).toBe(true);
+  });
+});
+
+describe('deleteDir()', () => {
+  test('delete a directory', async () => {
+    const unixTime = await getTime();
+    const workDirName = await getWorkDirName(`${unixTime}`);
+    await createDir(workDirName);
+    await deleteDir(workDirName);
+    const test = fs.existsSync(workDirName);
+    expect(test).toBe(false);
   });
 });
 

--- a/action.yml
+++ b/action.yml
@@ -77,3 +77,7 @@ inputs:
     description: 'Set files or directories to exclude from a publish directory.'
     required: false
     default: '.github'
+  cleanup_work_dir:
+    description: 'Clean up a working directory.'
+    required: false
+    default: 'false'

--- a/src/get-inputs.ts
+++ b/src/get-inputs.ts
@@ -29,6 +29,7 @@ export function showInputs(inps: Inputs): void {
 [INFO] EnableJekyll (DisableNoJekyll): ${inps.DisableNoJekyll}
 [INFO] CNAME: ${inps.CNAME}
 [INFO] ExcludeAssets ${inps.ExcludeAssets}
+[INFO] CleanupWorkDir: ${inps.CleanupWorkDir}
 `);
 }
 
@@ -67,7 +68,8 @@ export function getInputs(): Inputs {
     TagMessage: core.getInput('tag_message'),
     DisableNoJekyll: useBuiltinJekyll,
     CNAME: core.getInput('cname'),
-    ExcludeAssets: core.getInput('exclude_assets')
+    ExcludeAssets: core.getInput('exclude_assets'),
+    CleanupWorkDir: isBoolean(core.getInput('cleanup_work_dir'))
   };
 
   return inps;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,7 @@ export interface Inputs {
   readonly DisableNoJekyll: boolean;
   readonly CNAME: string;
   readonly ExcludeAssets: string;
+  readonly CleanupWorkDir: boolean;
 }
 
 export interface CmdResult {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {Inputs} from './interfaces';
 import {showInputs, getInputs} from './get-inputs';
 import {setTokens} from './set-tokens';
 import {setRepo, setCommitAuthor, getCommitMessage, commit, push, pushTag} from './git-utils';
-import {getWorkDirName, addNoJekyll, addCNAME, skipOnFork} from './utils';
+import {getWorkDirName, addNoJekyll, addCNAME, skipOnFork, deleteDir} from './utils';
 
 export async function run(): Promise<void> {
   try {
@@ -82,6 +82,12 @@ export async function run(): Promise<void> {
     await push(inps.PublishBranch, inps.ForceOrphan);
     await pushTag(inps.TagName, inps.TagMessage);
     core.endGroup();
+
+    if (inps.CleanupWorkDir) {
+      core.startGroup('Clean up working directory');
+      await deleteDir(workDir);
+      core.endGroup();
+    }
 
     core.info('[INFO] Action successfully completed');
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,14 @@ export async function createDir(dirPath: string): Promise<void> {
   return;
 }
 
+export async function deleteDir(dirPath: string): Promise<void> {
+  if (fs.existsSync(dirPath)) {
+    await io.rmRF(dirPath);
+    core.debug(`Deleted directory ${dirPath}`);
+    return;
+  }
+}
+
 export async function addNoJekyll(workDir: string, DisableNoJekyll: boolean): Promise<void> {
   if (DisableNoJekyll) {
     return;


### PR DESCRIPTION
This PR is adding `cleanup_work_dir` option to delete a working directory like `$HOME/actions_github_pages_*`.

### Issue
`actions-gh-pages` creates a working directoriy every runs, it messes up $HOME directory and annoys users of `self-hosted` runners. 

### Related issues
- #697 
- #686 