### PR TITLE
docs: replace deprecated set-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,7 +976,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
As of October 2022, the `set-output` construct is deprecated by GitHub for GitHub Actions. Source:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This commit changes the use of the construct for the Sphinx example in the README.md file.