### PR TITLE
docs: fix typo, bump hugo version

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
     about: Please ask questions about GitHub Actions here.
   - name: GitHub Pages Documentation
     url: https://docs.github.com/en/pages
-    about: GitHub Pages official documentaion here.
+    about: GitHub Pages official documentation here.
   - name: GitHub Actions Documentation
     url: https://docs.github.com/en/actions
     about: GitHub Actions official documentation here.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.101.0'
+          hugo-version: '0.110.0'
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
This PR fixes a typo I spotted and bumps `hugo` version in the sample script to latest release