### PR TITLE
refactor: prefer Node.js built-in fs method

### DIFF
--- a/__tests__/git-utils.test.ts
+++ b/__tests__/git-utils.test.ts
@@ -11,9 +11,8 @@ import {Inputs} from '../src/interfaces';
 import {getWorkDirName, createDir} from '../src/utils';
 import {CmdResult} from '../src/interfaces';
 import * as exec from '@actions/exec';
-import {cp, rm} from 'shelljs';
 import path from 'path';
-import fs from 'fs';
+import fs, {rmSync, cpSync} from 'fs';
 
 const testRoot = path.resolve(__dirname);
 
@@ -51,21 +50,29 @@ describe('copyAssets', () => {
   test('copy assets from publish_dir to root, delete .github', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    cpSync(path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir, {
+      recursive: true,
+      force: true
+    });
+    cpSync(gitTempDir, destDir, {recursive: true, force: true});
 
     await copyAssets(publishDir, destDir, '.github');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+
+    rmSync(publishDir, {recursive: true, force: true});
+    rmSync(destDir, {recursive: true, force: true});
   });
 
   test('copy assets from publish_dir to root, delete .github,main.js', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    cpSync(path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir, {
+      recursive: true,
+      force: true
+    });
+    cpSync(gitTempDir, destDir, {recursive: true, force: true});
 
     await copyAssets(publishDir, destDir, '.github,main.js');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
@@ -73,14 +80,19 @@ describe('copyAssets', () => {
     expect(fs.existsSync(path.resolve(destDir, 'main.js'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.js'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+
+    rmSync(publishDir, {recursive: true, force: true});
+    rmSync(destDir, {recursive: true, force: true});
   });
 
   test('copy assets from publish_dir to root, delete nothing', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    cpSync(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir, {
+      recursive: true,
+      force: true
+    });
+    cpSync(gitTempDir, destDir, {recursive: true, force: true});
 
     await copyAssets(publishDir, destDir, '');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeTruthy();
@@ -88,35 +100,47 @@ describe('copyAssets', () => {
     expect(fs.existsSync(path.resolve(destDir, 'main.js'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.js'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+
+    rmSync(publishDir, {recursive: true, force: true});
+    rmSync(destDir, {recursive: true, force: true});
   });
 
   test('copy assets from root to root, delete .github', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
-    cp('-Rf', gitTempDir, publishDir);
+    cpSync(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir, {
+      recursive: true,
+      force: true
+    });
+    cpSync(gitTempDir, destDir, {recursive: true, force: true});
+    cpSync(gitTempDir, publishDir, {recursive: true, force: true});
 
     await copyAssets(publishDir, destDir, '.github');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+
+    rmSync(publishDir, {recursive: true, force: true});
+    rmSync(destDir, {recursive: true, force: true});
   });
 
   test('copy assets from root to root, delete nothing', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
-    cp('-Rf', gitTempDir, publishDir);
+    cpSync(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir, {
+      recursive: true,
+      force: true
+    });
+    cpSync(gitTempDir, destDir, {recursive: true, force: true});
+    cpSync(gitTempDir, publishDir, {recursive: true, force: true});
 
     await copyAssets(publishDir, destDir, '');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+
+    rmSync(publishDir, {recursive: true, force: true});
+    rmSync(destDir, {recursive: true, force: true});
   });
 
   test.todo('copy assets from root to subdir, delete .github');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,7 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.1.1",
         "@actions/glob": "^0.4.0",
-        "@actions/io": "^1.1.2",
-        "@types/shelljs": "^0.8.11",
-        "shelljs": "^0.8.5"
+        "@actions/io": "^1.1.2"
       },
       "devDependencies": {
         "@types/jest": "^29.2.6",
@@ -1317,15 +1315,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1381,11 +1370,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -1395,7 +1379,8 @@
     "node_modules/@types/node": {
       "version": "16.18.77",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.77.tgz",
-      "integrity": "sha512-zwqAbRkHjGlxH9PBv8i9dmeaDpBRgfQDSFuREMF2Z+WUi8uc13gfRquMV/8LxBqwm+7jBz+doTVkEEA1CIWOnQ=="
+      "integrity": "sha512-zwqAbRkHjGlxH9PBv8i9dmeaDpBRgfQDSFuREMF2Z+WUi8uc13gfRquMV/8LxBqwm+7jBz+doTVkEEA1CIWOnQ==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1408,15 +1393,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
-    },
-    "node_modules/@types/shelljs": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.15.tgz",
-      "integrity": "sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==",
-      "dependencies": {
-        "@types/glob": "~7.2.0",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.0",
@@ -3426,7 +3402,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3445,7 +3422,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -3791,6 +3769,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3916,6 +3895,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4028,6 +4008,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4036,7 +4017,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4048,6 +4030,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -4062,6 +4045,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
       "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -6007,6 +5991,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6023,7 +6008,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6430,6 +6416,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -6475,6 +6462,7 @@
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
       "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
@@ -6636,6 +6624,7 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -7143,6 +7132,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8740,15 +8730,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -8804,11 +8785,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
-    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -8818,7 +8794,8 @@
     "@types/node": {
       "version": "16.18.77",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.77.tgz",
-      "integrity": "sha512-zwqAbRkHjGlxH9PBv8i9dmeaDpBRgfQDSFuREMF2Z+WUi8uc13gfRquMV/8LxBqwm+7jBz+doTVkEEA1CIWOnQ=="
+      "integrity": "sha512-zwqAbRkHjGlxH9PBv8i9dmeaDpBRgfQDSFuREMF2Z+WUi8uc13gfRquMV/8LxBqwm+7jBz+doTVkEEA1CIWOnQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -8831,15 +8808,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
-    },
-    "@types/shelljs": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.15.tgz",
-      "integrity": "sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==",
-      "requires": {
-        "@types/glob": "~7.2.0",
-        "@types/node": "*"
-      }
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -10307,7 +10275,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.3",
@@ -10319,7 +10288,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -10590,6 +10560,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10682,6 +10653,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10758,6 +10730,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10766,7 +10739,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -10777,7 +10751,8 @@
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -10789,6 +10764,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
       "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -12266,7 +12242,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -12277,7 +12254,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -12557,6 +12535,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -12590,6 +12569,7 @@
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
       "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
@@ -12696,6 +12676,7 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -13095,7 +13076,8 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.1.1",
-        "@actions/glob": "^0.4.0",
-        "@actions/io": "^1.1.2"
+        "@actions/glob": "^0.4.0"
       },
       "devDependencies": {
         "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
     "@actions/glob": "^0.4.0",
-    "@actions/io": "^1.1.2",
-    "@types/shelljs": "^0.8.11",
-    "shelljs": "^0.8.5"
+    "@actions/io": "^1.1.2"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
-    "@actions/glob": "^0.4.0",
-    "@actions/io": "^1.1.2"
+    "@actions/glob": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -2,11 +2,10 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as glob from '@actions/glob';
 import path from 'path';
-import fs from 'fs';
+import fs, {cpSync, rmSync} from 'fs';
 import {URL} from 'url';
 import {Inputs, CmdResult} from './interfaces';
 import {createDir} from './utils';
-import {cp, rm} from 'shelljs';
 
 export async function createBranchForce(branch: string): Promise<void> {
   await exec.exec('git', ['init']);
@@ -30,11 +29,12 @@ export async function deleteExcludedAssets(destDir: string, excludeAssets: strin
     return paths;
   })();
   const globber = await glob.create(excludedAssetPaths.join('\n'));
-  const files = await globber.glob();
+
   for await (const file of globber.globGenerator()) {
     core.info(`[INFO] delete ${file}`);
+    rmSync(file, {recursive: true, force: true});
   }
-  rm('-rf', files);
+
   return;
 }
 
@@ -53,11 +53,12 @@ export async function copyAssets(
   const dotGitPath = path.join(publishDir, '.git');
   if (fs.existsSync(dotGitPath)) {
     core.info(`[INFO] delete ${dotGitPath}`);
-    rm('-rf', dotGitPath);
+    rmSync(dotGitPath, {recursive: true, force: true});
   }
 
   core.info(`[INFO] copy ${publishDir} to ${destDir}`);
-  cp('-RfL', [`${publishDir}/*`, `${publishDir}/.*`], destDir);
+
+  cpSync(publishDir, destDir, {recursive: true, force: true});
 
   await deleteExcludedAssets(destDir, excludeAssets);
 

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
-import * as io from '@actions/io';
 import path from 'path';
 import fs from 'fs';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -17,7 +16,7 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
 
   const homeDir = await getHomeDir();
   const sshDir = path.join(homeDir, '.ssh');
-  await io.mkdirP(sshDir);
+  await fs.promises.mkdir(sshDir, {recursive: true});
   await exec.exec('chmod', ['700', sshDir]);
 
   const knownHosts = path.join(sshDir, 'known_hosts');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as io from '@actions/io';
 import path from 'path';
 import fs from 'fs';
 
@@ -24,7 +23,7 @@ export async function getWorkDirName(unixTime: string): Promise<string> {
 }
 
 export async function createDir(dirPath: string): Promise<void> {
-  await io.mkdirP(dirPath);
+  await fs.promises.mkdir(dirPath, {recursive: true});
   core.debug(`Created directory ${dirPath}`);
   return;
 }


### PR DESCRIPTION
The PR replaces the `shelljs` with the Node.js built-in fs method.

By removing the `shelljs`, `actions-gh-pages` now has fewer dependencies and faster boot-up speed.