### PR TITLE
feat: treeless clone

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -105,7 +105,15 @@ export async function setRepo(inps: Inputs, remoteURL: string, workDir: string):
   try {
     result.exitcode = await exec.exec(
       'git',
-      ['clone', '--depth=1', '--single-branch', '--branch', inps.PublishBranch, remoteURL, workDir],
+      [
+        'clone',
+        '--filter=tree:0',
+        '--single-branch',
+        '--branch',
+        inps.PublishBranch,
+        remoteURL,
+        workDir
+      ],
       options
     );
     if (result.exitcode === 0) {


### PR DESCRIPTION
Use the treeless clone (`git clone --filter=tree:0`) to speed up the initial git repo setup.

https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/