### PR TITLE
fix: pin 6 unpinned action(s),extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1
+        uses: peaceiris/actions-label-commenter@f0dbbef043eb1b150b566db36b0bdc8b7f505579 # v1
         env:
           RUNNER_DEBUG: 1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     permissions: {}
     steps:
       # https://github.com/peaceiris/actions-github-app-token
-      - uses: peaceiris/actions-github-app-token@v1.1.6
+      - uses: peaceiris/actions-github-app-token@652b86006ad2c113bdd5c478c9a98f359829847b # v1.1.6
         id: app
         with:
           app_id: ${{ secrets.GH_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # https://github.com/peaceiris/workflows/blob/main/create-release-npm/action.yml
-      - uses: peaceiris/workflows/create-release-npm@v0.20.1
+      - uses: peaceiris/workflows/create-release-npm@344651af76054dbb5c8231c3d0a18b109c029630 # v0.20.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: peaceiris/workflows/setup-node@v0.20.1
+      - uses: peaceiris/workflows/setup-node@344651af76054dbb5c8231c3d0a18b109c029630 # v0.20.1
         with:
           node-version-file: ".nvmrc"
 
@@ -66,7 +66,7 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: coverage
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
 
       - name: Run ncc
         run: npm run build
@@ -79,7 +79,7 @@ jobs:
 
       - name: Setup mdBook
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: peaceiris/actions-mdbook@v1.2.0
+        uses: peaceiris/actions-mdbook@adeb05db28a0c0004681db83893d56c0388ea9ea # v1.2.0
         with:
           mdbook-version: '0.4.5'
 

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -15,8 +15,11 @@ jobs:
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           export TAG_NAME="${GITHUB_REF##refs/tags/}"
           export TAG_MAJOR="${TAG_NAME%%.*}"
           git tag --force -a "${TAG_MAJOR}" -m "Release ${TAG_NAME}"
           git push --force origin "${TAG_MAJOR}"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `label-commenter.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `labeler.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `release.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `test.yml` | Pinned 3 action(s) to commit SHA |
| RGS-008 | high | `update-major-tag.yml` | Extracted 1 expression(s) to env vars |




## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since, where attackers compromise maintainer accounts and force-push malicious code to mutable action tags - every downstream project referencing those tags then executes the attacker's code with full access to secrets and deployment credentials.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've had 22 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))