### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,27 @@
 cicd:
   - changed-files:
-      - any-glob-to-any-file: .github/workflows/*
+      - any-glob-to-any-file: '.github/workflows/*'
 
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
-          - .nvmrc
-          - package.json
-          - package-lock.json
+          - '.nvmrc'
+          - 'package.json'
+          - 'package-lock.json'
 
 documentation:
   - changed-files:
-      - any-glob-to-any-file: README.md
+      - any-glob-to-any-file: 'README.md'
 
 test:
   - changed-files:
-      - any-glob-to-any-file: __tests__
+      - any-glob-to-any-file: '__tests__/**'
 
 docker:
   - changed-files:
       - any-glob-to-any-file:
-          - .devcontainer/*
-          - .dockerignore
-          - Dockerfile
-          - Makefile
-          - docker-compose.yml
+          - '.devcontainer/*'
+          - '.dockerignore'
+          - 'Dockerfile'
+          - 'Makefile'
+          - 'docker-compose.yml'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,19 +6,26 @@ on:
       - main
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: javascript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -17,11 +17,12 @@ permissions:
 
 jobs:
   comment:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1
+        uses: peaceiris/actions-label-commenter@f0dbbef043eb1b150b566db36b0bdc8b7f505579 # v1.10.0
         env:
           RUNNER_DEBUG: 1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 1
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     permissions: {}
     steps:
       # https://github.com/peaceiris/actions-github-app-token
-      - uses: peaceiris/actions-github-app-token@v1.1.6
+      - uses: peaceiris/actions-github-app-token@652b86006ad2c113bdd5c478c9a98f359829847b # v1.1.6
         id: app
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       # https://github.com/actions/labeler
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: "${{ steps.app.outputs.token }}"

--- a/.github/workflows/pages-status-check.yml
+++ b/.github/workflows/pages-status-check.yml
@@ -4,7 +4,9 @@ on: page_build
 
 jobs:
   pages-status-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - name: check status
         run: |

--- a/.github/workflows/purge-readme-image-cache.yml
+++ b/.github/workflows/purge-readme-image-cache.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   purge:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
     steps:
-
-    - run: >
-        curl -sL https://github.com/${GITHUB_REPOSITORY} |
-        grep -oE '<img src="https?://camo.githubusercontent.com/[^"]+' |
-        sed -e 's/<img src="//' |
-        xargs -I % curl -sX PURGE %
+      - run: >
+          curl -sL "https://github.com/${GITHUB_REPOSITORY}" |
+          grep -oE '<img src="https?://camo.githubusercontent.com/[^"]+' |
+          sed -e 's/<img src="//' |
+          xargs -I % curl -sX PURGE "%"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # https://github.com/peaceiris/workflows/blob/main/create-release-npm/action.yml
-      - uses: peaceiris/workflows/create-release-npm@v0.21.6
+      - uses: peaceiris/workflows/create-release-npm@99f66a30a38f806fd0df9014275c7cef0b6d9ca5 # v0.21.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -28,9 +29,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
@@ -44,7 +45,7 @@ jobs:
       - run: npm ci --ignore-scripts
 
       - name: npm audit
-        if: startsWith(matrix.os, 'ubuntu-22.04')
+        if: startsWith(matrix.os, 'ubuntu-24.04')
         run: |
           npm audit > ./audit.log || true
           if ! [ "$(cat ./audit.log | wc -l)" = 1 ]; then
@@ -53,22 +54,22 @@ jobs:
           rm ./audit.log
 
       - name: Run prettier
-        if: startsWith(matrix.os, 'ubuntu-22.04')
+        if: startsWith(matrix.os, 'ubuntu-24.04')
         run: npm run format:check
 
       - name: Run eslint
-        if: startsWith(matrix.os, 'ubuntu-22.04')
+        if: startsWith(matrix.os, 'ubuntu-24.04')
         run: npm run lint
 
       - run: npm test
 
       - name: Upload test coverage as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.os }}
           path: coverage
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
 
       - name: Run build
         run: npm run build
@@ -81,7 +82,7 @@ jobs:
 
       - name: Setup mdBook
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: peaceiris/actions-mdbook@v2.0.0
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2.0.0
         with:
           mdbook-version: '0.4.5'
 

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -6,10 +6,12 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 1
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update major tag
         run: |


### PR DESCRIPTION
## 概要
- Pin GitHub Actions workflow dependencies to immutable commit SHAs with readable version comments.
- Add explicit job permissions and timeouts, and move lightweight workflows to `ubuntu-slim` or `ubuntu-24.04`.
- Update `actions/labeler` to v6.1.0 and migrate `.github/labeler.yml` to the current config format.

## 参考
- No related issue.
- `lib/index.js` was generated locally only so `actionlint` could resolve `uses: ./`; it was not committed.
- Expected secret references were kept as GitHub Actions expressions only.

## Test plan
- [x] `npm ci --ignore-scripts`
- [x] `npm run build`
- [x] `actionlint`
- [x] `npm run lint`
- [x] `npm test`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third‑party GitHub Action references for deterministic workflows and improved security.
  * Standardized and tightened job permissions across workflows.
  * Updated workflow runner environments and added job timeouts to improve reliability.
  * Restructured label matching rules for the repository labeler, expanding test globs and consolidating Docker-related patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/actions-gh-pages/pull/1156)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->