### PR TITLE
refactor: drop `shelljs`

### DIFF
--- a/__tests__/git-utils.test.ts
+++ b/__tests__/git-utils.test.ts
@@ -11,7 +11,6 @@ import {Inputs} from '../src/interfaces';
 import {getWorkDirName, createDir} from '../src/utils';
 import {CmdResult} from '../src/interfaces';
 import * as exec from '@actions/exec';
-import {cp, rm} from 'shelljs';
 import path from 'path';
 import fs from 'fs';
 
@@ -21,6 +20,14 @@ async function createTestDir(name: string): Promise<string> {
   const date = new Date();
   const unixTime = date.getTime();
   return await getWorkDirName(`${unixTime}_${name}`);
+}
+
+async function copy(source: string, destination: string): Promise<void> {
+  await fs.promises.cp(source, destination, {dereference: true, force: true, recursive: true});
+}
+
+async function remove(...paths: string[]): Promise<void> {
+  await Promise.all(paths.map(path => fs.promises.rm(path, {force: true, recursive: true})));
 }
 
 beforeEach(() => {
@@ -51,21 +58,21 @@ describe('copyAssets', () => {
   test('copy assets from publish_dir to root, delete .github', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    await copy(path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
+    await copy(gitTempDir, destDir);
 
     await copyAssets(publishDir, destDir, '.github');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+    await remove(publishDir, destDir);
   });
 
   test('copy assets from publish_dir to root, delete .github,main.js', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    await copy(path.resolve(testRoot, 'fixtures/publish_dir_1'), publishDir);
+    await copy(gitTempDir, destDir);
 
     await copyAssets(publishDir, destDir, '.github,main.js');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
@@ -73,14 +80,14 @@ describe('copyAssets', () => {
     expect(fs.existsSync(path.resolve(destDir, 'main.js'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.js'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+    await remove(publishDir, destDir);
   });
 
   test('copy assets from publish_dir to root, delete nothing', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
+    await copy(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
+    await copy(gitTempDir, destDir);
 
     await copyAssets(publishDir, destDir, '');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeTruthy();
@@ -88,35 +95,35 @@ describe('copyAssets', () => {
     expect(fs.existsSync(path.resolve(destDir, 'main.js'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.js'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+    await remove(publishDir, destDir);
   });
 
   test('copy assets from root to root, delete .github', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
-    cp('-Rf', gitTempDir, publishDir);
+    await copy(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
+    await copy(gitTempDir, destDir);
+    await copy(gitTempDir, publishDir);
 
     await copyAssets(publishDir, destDir, '.github');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeFalsy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+    await remove(publishDir, destDir);
   });
 
   test('copy assets from root to root, delete nothing', async () => {
     const publishDir = await createTestDir('src');
     const destDir = await createTestDir('dst');
-    cp('-Rf', path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
-    cp('-Rf', gitTempDir, destDir);
-    cp('-Rf', gitTempDir, publishDir);
+    await copy(path.resolve(testRoot, 'fixtures/publish_dir_root'), publishDir);
+    await copy(gitTempDir, destDir);
+    await copy(gitTempDir, publishDir);
 
     await copyAssets(publishDir, destDir, '');
     expect(fs.existsSync(path.resolve(destDir, '.github'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'index.html'))).toBeTruthy();
     expect(fs.existsSync(path.resolve(destDir, 'assets/lib.css'))).toBeTruthy();
-    rm('-rf', publishDir, destDir);
+    await remove(publishDir, destDir);
   });
 
   test.todo('copy assets from root to subdir, delete .github');

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,13 @@
         "@actions/exec": "3.0.0",
         "@actions/github": "9.1.1",
         "@actions/glob": "0.7.0",
-        "@actions/io": "3.0.2",
-        "shelljs": "0.10.0"
+        "@actions/io": "3.0.2"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@types/jest": "30.0.0",
         "@types/js-yaml": "4.0.9",
         "@types/node": "25.9.4",
-        "@types/shelljs": "0.10.0",
         "@typescript-eslint/eslint-plugin": "8.61.0",
         "@typescript-eslint/parser": "8.61.0",
         "esbuild": "0.28.1",
@@ -1833,41 +1831,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -2192,17 +2155,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha512-OEfyhE5Ox+FeoHbhrEDwm0kXxntO6nsyMRCFvNsIBHPZu5rV1w2OjPcLclaC/IZ1TlzZPgbeMfwAZEi5N238yQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "fast-glob": "^3.3.2"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3093,18 +3045,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -3798,6 +3738,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4484,6 +4425,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -4507,6 +4449,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/exit-x": {
@@ -4551,34 +4494,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4592,15 +4507,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4667,18 +4573,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -4982,6 +4876,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5250,6 +5145,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -5374,6 +5270,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5409,21 +5306,13 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-obj": {
@@ -5450,6 +5339,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5482,6 +5372,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6858,46 +6749,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7070,6 +6929,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -7092,6 +6952,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -7213,6 +7074,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7495,26 +7357,6 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -7790,45 +7632,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -7868,6 +7677,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7880,22 +7690,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/signal-exit": {
@@ -8501,6 +8299,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8702,18 +8501,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/trim-newlines": {
       "version": "5.0.0",
@@ -9053,6 +8840,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -51,15 +51,13 @@
     "@actions/exec": "3.0.0",
     "@actions/github": "9.1.1",
     "@actions/glob": "0.7.0",
-    "@actions/io": "3.0.2",
-    "shelljs": "0.10.0"
+    "@actions/io": "3.0.2"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/jest": "30.0.0",
     "@types/js-yaml": "4.0.9",
     "@types/node": "25.9.4",
-    "@types/shelljs": "0.10.0",
     "@typescript-eslint/eslint-plugin": "8.61.0",
     "@typescript-eslint/parser": "8.61.0",
     "esbuild": "0.28.1",

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -6,7 +6,6 @@ import fs from 'fs';
 import {URL} from 'url';
 import {Inputs, CmdResult} from './interfaces';
 import {createDir} from './utils';
-import {rm} from 'shelljs';
 
 export async function createBranchForce(branch: string): Promise<void> {
   await exec.exec('git', ['init']);
@@ -35,7 +34,7 @@ export async function deleteExcludedAssets(destDir: string, excludeAssets: strin
     core.info(`[INFO] delete ${file}`);
   }
   if (files.length > 0) {
-    rm('-rf', files);
+    await Promise.all(files.map(file => fs.promises.rm(file, {force: true, recursive: true})));
   }
   return;
 }
@@ -66,7 +65,7 @@ export async function copyAssets(
   const dotGitPath = path.join(publishDir, '.git');
   if (fs.existsSync(dotGitPath)) {
     core.info(`[INFO] delete ${dotGitPath}`);
-    rm('-rf', dotGitPath);
+    await fs.promises.rm(dotGitPath, {force: true, recursive: true});
   }
 
   core.info(`[INFO] copy ${publishDir} to ${destDir}`);


### PR DESCRIPTION
Replace `shelljs` rm & cp w/ Node.js built-in `fs#cp` and `fs#rm` API.

<img width="568" height="119" alt="image" src="https://github.com/user-attachments/assets/9ebb4fb0-ac55-40d7-9c47-7695ba9faf35" />

All tests passed on my machine locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary files, excluded assets, and generated Git metadata to ensure directories are fully removed.
  * Enhanced reliability by completing filesystem operations before continuing.
* **Chores**
  * Replaced reliance on a third-party shell utility with built-in Node filesystem promises.
  * Updated tests to use the new async filesystem behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->