### PR TITLE
refactor: replace `@actions/io` w/ Node.js `fs#mkdir` recursive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@actions/exec": "3.0.0",
         "@actions/github": "9.1.1",
         "@actions/glob": "0.7.0",
-        "@actions/io": "3.0.2",
         "shelljs": "0.10.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@actions/exec": "3.0.0",
     "@actions/github": "9.1.1",
     "@actions/glob": "0.7.0",
-    "@actions/io": "3.0.2",
     "shelljs": "0.10.0"
   },
   "devDependencies": {

--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
-import * as io from '@actions/io';
 import {execFileSync, spawnSync} from 'child_process';
 import path from 'path';
 import fs from 'fs';
@@ -14,7 +13,7 @@ export async function setSSHKey(inps: Inputs, publishRepo: string): Promise<stri
 
   const homeDir = await getHomeDir();
   const sshDir = path.join(homeDir, '.ssh');
-  await io.mkdirP(sshDir);
+  await fs.promises.mkdir(sshDir, {recursive: true});
   await exec.exec('chmod', ['700', sshDir]);
 
   const knownHosts = path.join(sshDir, 'known_hosts');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as io from '@actions/io';
 import path from 'path';
 import fs from 'fs';
 
@@ -19,7 +18,7 @@ export async function getWorkDirName(unixTime: string): Promise<string> {
 }
 
 export async function createDir(dirPath: string): Promise<void> {
-  await io.mkdirP(dirPath);
+  await fs.promises.mkdir(dirPath, {recursive: true});
   core.debug(`Created directory ${dirPath}`);
   return;
 }


### PR DESCRIPTION
With `recursive: true` we can ensure all parent folders are created and won't reject w/ already existing folders.

https://nodejs.org/api/fs.html#fspromisesmkdirpath-options

<img width="454" height="122" alt="image" src="https://github.com/user-attachments/assets/561f507a-3a1c-420a-aaf0-2677f33158e3" />

All tests passed on my machine locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated directory creation handling for improved reliability.
  * Removed an unused package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->