### PR TITLE
perf: reuse glob results when logging excluded assets

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -31,7 +31,7 @@ export async function deleteExcludedAssets(destDir: string, excludeAssets: strin
   })();
   const globber = await glob.create(excludedAssetPaths.join('\n'));
   const files = await globber.glob();
-  for await (const file of globber.globGenerator()) {
+  for (const file of files) {
     core.info(`[INFO] delete ${file}`);
   }
   if (files.length > 0) {


### PR DESCRIPTION
Avoid calling `globGenerator` twice. It has been called in `globber.glob()`.

https://github.com/actions/toolkit/blob/193fa46c20fde8b0ed54194bc08b841c78c0776d/packages/glob/src/internal-globber.ts#L59-L62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset cleanup reliability by processing the complete set of discovered files before deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->